### PR TITLE
ENYO-5887: Test command in package.json incorrect

### DIFF
--- a/packages/agate/template/package.json
+++ b/packages/agate/template/package.json
@@ -12,8 +12,8 @@
     "clean": "enact clean",
     "lint": "enact lint .",
     "license": "enact license",
-    "test": "enact test start --single-run",
-    "test-watch": "enact test start"
+    "test": "enact test",
+    "test-watch": "enact test --watch"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/packages/cordova/template/package.json
+++ b/packages/cordova/template/package.json
@@ -12,8 +12,8 @@
     "clean": "enact clean www",
     "lint": "enact lint  -- --ignore-pattern \"www/*\" .",
     "license": "enact license",
-    "test": "enact test start --single-run",
-    "test-watch": "enact test start"
+    "test": "enact test",
+    "test-watch": "enact test --watch"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/packages/electron/template/package.json
+++ b/packages/electron/template/package.json
@@ -20,8 +20,8 @@
     "clean": "enact clean bin",
     "lint": "enact lint  -- --env=browser,node --ignore-pattern \"bin/*\" .",
     "license": "enact license",
-    "test": "enact test start --single-run",
-    "test-watch": "enact test start"
+    "test": "enact test",
+    "test-watch": "enact test --watch"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/packages/moonstone/template/package.json
+++ b/packages/moonstone/template/package.json
@@ -12,8 +12,8 @@
     "clean": "enact clean",
     "lint": "enact lint .",
     "license": "enact license",
-    "test": "enact test start --single-run",
-    "test-watch": "enact test start"
+    "test": "enact test",
+    "test-watch": "enact test --watch"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/packages/typescript/template/package.json
+++ b/packages/typescript/template/package.json
@@ -12,8 +12,8 @@
     "clean": "enact clean",
     "lint": "enact lint .",
     "license": "enact license",
-    "test": "enact test start --single-run",
-    "test-watch": "enact test start"
+    "test": "enact test",
+    "test-watch": "enact test --watch"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/packages/webostv/template/package.json
+++ b/packages/webostv/template/package.json
@@ -12,8 +12,8 @@
     "clean": "enact clean",
     "lint": "enact lint .",
     "license": "enact license",
-    "test": "enact test start --single-run",
-    "test-watch": "enact test start"
+    "test": "enact test",
+    "test-watch": "enact test --watch"
   },
   "license": "UNLICENSED",
   "private": true,


### PR DESCRIPTION
Update each template's `test` and `test-watch` NPM script tasks to use correct CLI 2.x Jest commands (rather than old CLI 1.x Karma commands).

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>