### PR TITLE
PLAT-80499: Transition to external iLib NPM module

### DIFF
--- a/packages/cordova/template/package.json
+++ b/packages/cordova/template/package.json
@@ -38,7 +38,7 @@
     "@enact/spotlight": "^2.0.0",
     "@enact/ui": ">=3.0.0-alpha <3.0.0",
     "@enact/webos": ">=3.0.0-alpha <3.0.0",
-    "ilib-webos-tv": "14.2.0-webostv1",
+    "ilib": "^14.2.0",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/packages/cordova/template/package.json
+++ b/packages/cordova/template/package.json
@@ -38,6 +38,7 @@
     "@enact/spotlight": "^2.0.0",
     "@enact/ui": ">=3.0.0-alpha <3.0.0",
     "@enact/webos": ">=3.0.0-alpha <3.0.0",
+    "ilib-webos-tv": "14.2.0-webostv1",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/packages/electron/template/package.json
+++ b/packages/electron/template/package.json
@@ -53,7 +53,7 @@
     "@enact/ui": ">=3.0.0-alpha <3.0.0",
     "@enact/webos": ">=3.0.0-alpha <3.0.0",
     "electron": "^5.0.0",
-    "ilib-webos-tv": "14.2.0-webostv1",
+    "ilib": "^14.2.0",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/packages/electron/template/package.json
+++ b/packages/electron/template/package.json
@@ -53,6 +53,7 @@
     "@enact/ui": ">=3.0.0-alpha <3.0.0",
     "@enact/webos": ">=3.0.0-alpha <3.0.0",
     "electron": "^5.0.0",
+    "ilib-webos-tv": "14.2.0-webostv1",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/packages/moonstone/template/package.json
+++ b/packages/moonstone/template/package.json
@@ -35,7 +35,7 @@
     "@enact/moonstone": ">=3.0.0-alpha <3.0.0",
     "@enact/spotlight": ">=3.0.0-alpha <3.0.0",
     "@enact/ui": ">=3.0.0-alpha <3.0.0",
-    "ilib-webos-tv": "14.2.0-webostv1",
+    "ilib": "^14.2.0",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/packages/moonstone/template/package.json
+++ b/packages/moonstone/template/package.json
@@ -35,6 +35,7 @@
     "@enact/moonstone": ">=3.0.0-alpha <3.0.0",
     "@enact/spotlight": ">=3.0.0-alpha <3.0.0",
     "@enact/ui": ">=3.0.0-alpha <3.0.0",
+    "ilib-webos-tv": "14.2.0-webostv1",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/packages/typescript/template/package.json
+++ b/packages/typescript/template/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.0.11",
-    "ilib-webos-tv": "14.2.0-webostv1",
+    "ilib": "^14.2.0",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/packages/typescript/template/package.json
+++ b/packages/typescript/template/package.json
@@ -38,6 +38,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.0.11",
+    "ilib-webos-tv": "14.2.0-webostv1",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",

--- a/packages/webostv/template/package.json
+++ b/packages/webostv/template/package.json
@@ -36,6 +36,7 @@
     "@enact/spotlight": ">=3.0.0-alpha <3.0.0",
     "@enact/ui": ">=3.0.0-alpha <3.0.0",
     "@enact/webos": ">=3.0.0-alpha <3.0.0",
+    "ilib-webos-tv": "14.2.0-webostv1",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/packages/webostv/template/package.json
+++ b/packages/webostv/template/package.json
@@ -36,7 +36,7 @@
     "@enact/spotlight": ">=3.0.0-alpha <3.0.0",
     "@enact/ui": ">=3.0.0-alpha <3.0.0",
     "@enact/webos": ">=3.0.0-alpha <3.0.0",
-    "ilib-webos-tv": "14.2.0-webostv1",
+    "ilib": "^14.2.0",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"

--- a/packages/webostv/template/package.json
+++ b/packages/webostv/template/package.json
@@ -18,6 +18,9 @@
   "license": "UNLICENSED",
   "private": true,
   "repository": "",
+  "engines": {
+    "npm" : ">=6.9.0"
+  },
   "enact": {
     "theme": "moonstone"
   },
@@ -36,7 +39,7 @@
     "@enact/spotlight": ">=3.0.0-alpha <3.0.0",
     "@enact/ui": ">=3.0.0-alpha <3.0.0",
     "@enact/webos": ">=3.0.0-alpha <3.0.0",
-    "ilib": "^14.2.0",
+    "ilib": "npm:ilib-webos-tv@^14.2.0-webostv1",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"


### PR DESCRIPTION
As part of transition from an internal iLib within `@enact/i18n` to an external `ilib` package, update the app template dependencies.

Additionally, update the webOS TV template to use an NPM alias of `ilib-webos-tv` for `ilib` dependency. This requires NPM >=6.9.0 so the default engine value is also set.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>