### PR TITLE
Agate NPM release dependency, starting with 1.0.0-alpha.16

### DIFF
--- a/packages/agate/template/package.json
+++ b/packages/agate/template/package.json
@@ -30,7 +30,7 @@
     "dist/*"
   ],
   "dependencies": {
-    "@enact/agate": "enactjs/agate",
+    "@enact/agate": "^1.0.0-alpha.16",
     "@enact/core": "^3.2.0",
     "@enact/i18n": "^3.2.0",
     "@enact/spotlight": "^3.2.0",

--- a/packages/webosauto/template/package.json
+++ b/packages/webosauto/template/package.json
@@ -33,7 +33,7 @@
     "dist/*"
   ],
   "dependencies": {
-    "@enact/agate": "https://github.com/enactjs/agate",
+    "@enact/agate": "^1.0.0-alpha.16",
     "@enact/core": "^3.2.0",
     "@enact/i18n": "^3.2.0",
     "@enact/spotlight": "^3.2.0",

--- a/packages/webosauto/template/package.json
+++ b/packages/webosauto/template/package.json
@@ -18,9 +18,6 @@
   "license": "UNLICENSED",
   "private": true,
   "repository": "",
-  "engines": {
-    "npm": ">=6.9.0"
-  },
   "enact": {
     "theme": "agate"
   },


### PR DESCRIPTION
Updates `agate` and `webosauto` to use Agate's NPM release, starting with 1.0.0-alpha.16.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>