### PR TITLE
PLAT-117143: Enact template less file missing proper comments

### DIFF
--- a/packages/agate/template/src/App/App.module.less
+++ b/packages/agate/template/src/App/App.module.less
@@ -1,3 +1,3 @@
 .app {
-	// styles can be put here
+	/* styles can be put here */
 }

--- a/packages/cordova/template/src/App/App.module.less
+++ b/packages/cordova/template/src/App/App.module.less
@@ -1,3 +1,3 @@
 .app {
-	// styles can be put here
+	/* styles can be put here */
 }

--- a/packages/electron/template/renderer/App/App.module.less
+++ b/packages/electron/template/renderer/App/App.module.less
@@ -1,3 +1,3 @@
 .app {
-	// styles can be put here
+	/* styles can be put here */
 }

--- a/packages/moonstone/template/src/App/App.module.less
+++ b/packages/moonstone/template/src/App/App.module.less
@@ -1,3 +1,3 @@
 .app {
-	// styles can be put here
+	/* styles can be put here */
 }

--- a/packages/typescript/template/src/App/App.module.less
+++ b/packages/typescript/template/src/App/App.module.less
@@ -1,3 +1,3 @@
 .app {
-	// styles can be put here
+	/* styles can be put here */
 }

--- a/packages/webosauto/template/src/App/App.module.less
+++ b/packages/webosauto/template/src/App/App.module.less
@@ -1,3 +1,3 @@
 .app {
-	// styles can be put here
+	/* styles can be put here */
 }

--- a/packages/webostv/template/src/App/App.module.less
+++ b/packages/webostv/template/src/App/App.module.less
@@ -1,3 +1,3 @@
 .app {
-	// styles can be put here
+	/* styles can be put here */
 }


### PR DESCRIPTION
Empty classnames that should be preserved to not cause global class name leakage should be set off with C-style block comments. Currently, the templates use line comments. This PR fixes to use proper comments style.

Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)