### PR TITLE
WRO-659: Modify enzyme to testing-library in README.md

### DIFF
--- a/packages/agate/template/README.md
+++ b/packages/agate/template/README.md
@@ -124,7 +124,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and Enzyme are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/agate/template/README.md
+++ b/packages/agate/template/README.md
@@ -124,7 +124,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Jest and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/cordova/template/README.md
+++ b/packages/cordova/template/README.md
@@ -128,7 +128,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Jest and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/cordova/template/README.md
+++ b/packages/cordova/template/README.md
@@ -128,7 +128,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and Enzyme are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/electron/template/README.md
+++ b/packages/electron/template/README.md
@@ -140,7 +140,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and Enzyme are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/electron/template/README.md
+++ b/packages/electron/template/README.md
@@ -140,7 +140,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Jest and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/moonstone/template/README.md
+++ b/packages/moonstone/template/README.md
@@ -124,7 +124,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and Enzyme are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/moonstone/template/README.md
+++ b/packages/moonstone/template/README.md
@@ -124,7 +124,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Jest and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/sandstone/template/README.md
+++ b/packages/sandstone/template/README.md
@@ -124,7 +124,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and Enzyme are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/sandstone/template/README.md
+++ b/packages/sandstone/template/README.md
@@ -124,7 +124,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Jest and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/typescript/template/README.md
+++ b/packages/typescript/template/README.md
@@ -128,7 +128,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Jest and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/typescript/template/README.md
+++ b/packages/typescript/template/README.md
@@ -128,7 +128,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and Enzyme are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/webosauto/template/README.md
+++ b/packages/webosauto/template/README.md
@@ -125,7 +125,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Jest and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/webosauto/template/README.md
+++ b/packages/webosauto/template/README.md
@@ -125,7 +125,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and Enzyme are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/webostv/template/README.md
+++ b/packages/webostv/template/README.md
@@ -125,7 +125,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Jest and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>

--- a/packages/webostv/template/README.md
+++ b/packages/webostv/template/README.md
@@ -125,7 +125,7 @@ npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel 
 
 ## Installing a Dependency
 
-The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and Enzyme are as development dependencies. You may install other dependencies with `npm`:
+The generated project includes Enact (and all its libraries). It also includes React and ReactDOM.  For test writing, both Sinon and @testing-library/react are as development dependencies. You may install other dependencies with `npm`:
 
 ```sh
 npm install --save <package-name>


### PR DESCRIPTION
### Issue Resolved / Feature Added
Remove enzyme support and dependencies in 5.0.0.

### Resolution
* Modify README.md word `enzyme` to `testing-library`

### Additional Considerations

### Links
WRO-659

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)