### PR TITLE
WRP-5254: Changed templates "eslintConfig" to use eslint-config-enact-proxy

### DIFF
--- a/packages/agate/template/package.json
+++ b/packages/agate/template/package.json
@@ -22,7 +22,7 @@
     "theme": "agate"
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -40,5 +40,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "web-vitals": "^3.1.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/packages/cordova/template/package.json
+++ b/packages/cordova/template/package.json
@@ -24,7 +24,7 @@
   },
   "cordova": {},
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -43,5 +43,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "web-vitals": "^3.1.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/packages/electron/template/package.json
+++ b/packages/electron/template/package.json
@@ -33,7 +33,7 @@
     "Electron >=5.0"
   ],
   "eslintConfig": {
-    "extends": "enact",
+    "extends": "enact-proxy",
     "env": {
       "browser": true,
       "node": true
@@ -61,6 +61,7 @@
   "devDependencies": {
     "electron-packager": "^17.1.1",
     "electron-rebuild": "^3.2.9",
+    "eslint-config-enact-proxy": "^1.0.5",
     "foreman": "^3.0.1"
   }
 }

--- a/packages/moonstone/template/package.json
+++ b/packages/moonstone/template/package.json
@@ -22,7 +22,7 @@
     "theme": "moonstone"
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -40,5 +40,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "web-vitals": "^3.1.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/packages/sandstone/template/package.json
+++ b/packages/sandstone/template/package.json
@@ -22,7 +22,7 @@
     "theme": "sandstone"
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -40,5 +40,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "web-vitals": "^3.1.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/packages/typescript/template/package.json
+++ b/packages/typescript/template/package.json
@@ -22,7 +22,7 @@
     "theme": "sandstone"
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -44,5 +44,8 @@
     "react-dom": "^18.2.0",
     "typescript": "^4.9.4",
     "web-vitals": "^3.1.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/packages/webosauto/template/package.json
+++ b/packages/webosauto/template/package.json
@@ -22,7 +22,7 @@
     "theme": "agate"
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -41,5 +41,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "web-vitals": "^3.1.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }

--- a/packages/webostv/template/package.json
+++ b/packages/webostv/template/package.json
@@ -25,7 +25,7 @@
     "theme": "sandstone"
   },
   "eslintConfig": {
-    "extends": "enact"
+    "extends": "enact-proxy"
   },
   "eslintIgnore": [
     "node_modules/*",
@@ -44,5 +44,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "web-vitals": "^3.1.1"
+  },
+  "devDependencies": {
+    "eslint-config-enact-proxy": "^1.0.5"
   }
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
At the moment, templates doesn't have eslint-config-enact-proxy installed which allows linting through the eslint command and enables the in-editor linting function in the IDE.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Changed templates to use eslint-config-enact-proxy by adding the commands to each templates package.json.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-5254

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com