### PR TITLE
WRP-13733: Updated electron dependency to v24 in templates

### DIFF
--- a/packages/electron/template/package.json
+++ b/packages/electron/template/package.json
@@ -52,7 +52,7 @@
     "@enact/spotlight": "^4.6.2",
     "@enact/ui": "^4.6.2",
     "@enact/webos": "^4.6.2",
-    "electron": "^22.1.0",
+    "electron": "^24.1.2",
     "ilib": "^14.17.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`electron` dependency in packages/electron/template needs to be updated to latest version.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated `electron` version to ^24.1.2. There were no breaking changes affecting enact electron template.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-13733

### Comments