### PR TITLE
WRP-24431: Updating electron and types/node major dependency

### DIFF
--- a/packages/electron/template/package.json
+++ b/packages/electron/template/package.json
@@ -30,7 +30,7 @@
     "theme": "sandstone"
   },
   "browserslist": [
-    "Electron >=5.0"
+    "Electron >=26.0"
   ],
   "eslintConfig": {
     "extends": "enact-proxy",

--- a/packages/electron/template/package.json
+++ b/packages/electron/template/package.json
@@ -52,7 +52,7 @@
     "@enact/spotlight": "^4.7.2",
     "@enact/ui": "^4.7.2",
     "@enact/webos": "^4.7.2",
-    "electron": "^24.1.2",
+    "electron": "^26.0.0",
     "ilib": "^14.17.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/packages/typescript/template/package.json
+++ b/packages/typescript/template/package.json
@@ -35,7 +35,7 @@
     "@enact/sandstone": "^2.7.4",
     "@enact/spotlight": "^4.7.2",
     "@enact/ui": "^4.7.2",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.5.1",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "ilib": "^14.17.0",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`electron` v26 and `@types/node` v20 has been released.
This modules needs to be updated to the latest node modules to fix security vulnerabilities.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Updated `electron` and `types/mode` module to the latest version.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
There were no breaking changes affecting this repository.


### Links
[//]: # (Related issues, references)
WRP-24431
https://github.com/electron/electron/releases  https://github.com/electron/electron/tree/v26.0.0 
https://www.electronjs.org/docs/latest/breaking-changes
https://github.com/DefinitelyTyped/DefinitelyTyped/commits/master/types/node

### Comments
Enact-DCO-1.0-Signed-off-by: Andrei Tirla andrei.tirla@lgepartner.com