### PR TITLE
WRQ-19494: css-loader v7 migration

### DIFF
--- a/packages/agate/template/src/App/App.js
+++ b/packages/agate/template/src/App/App.js
@@ -4,7 +4,7 @@ import {Panels} from '@enact/agate/Panels';
 
 import MainPanel from '../views/MainPanel';
 
-import css from './App.module.less';
+import * as css from './App.module.less';
 
 const App = kind({
 	name: 'App',

--- a/packages/cordova/template/src/App/App.js
+++ b/packages/cordova/template/src/App/App.js
@@ -4,7 +4,7 @@ import Panels from '@enact/moonstone/Panels';
 
 import MainPanel from '../views/MainPanel';
 
-import css from './App.module.less';
+import * as css from './App.module.less';
 
 const App = kind({
 	name: 'App',

--- a/packages/electron/template/renderer/App/App.js
+++ b/packages/electron/template/renderer/App/App.js
@@ -4,7 +4,7 @@ import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 
 import MainPanel from '../views/MainPanel';
 
-import css from './App.module.less';
+import * as css from './App.module.less';
 
 const App = kind({
 	name: 'App',

--- a/packages/sandstone/template/src/App/App.js
+++ b/packages/sandstone/template/src/App/App.js
@@ -4,7 +4,7 @@ import Panels from '@enact/sandstone/Panels';
 
 import MainPanel from '../views/MainPanel';
 
-import css from './App.module.less';
+import * as css from './App.module.less';
 
 const App = kind({
 	name: 'App',

--- a/packages/theme/template/BodyText/BodyText.js
+++ b/packages/theme/template/BodyText/BodyText.js
@@ -17,7 +17,7 @@ import compose from 'ramda/src/compose';
 
 import Skinnable from '../Skinnable';
 
-import componentCss from './BodyText.module.less';
+import * as componentCss from './BodyText.module.less';
 
 /**
  * A simple text block component.

--- a/packages/theme/template/Button/Button.js
+++ b/packages/theme/template/Button/Button.js
@@ -19,7 +19,7 @@ import compose from 'ramda/src/compose';
 import Icon from '../Icon';
 import Skinnable from '../Skinnable';
 
-import componentCss from './Button.module.less';
+import * as componentCss from './Button.module.less';
 
 /**
  * A button component.

--- a/packages/theme/template/Checkbox/Checkbox.js
+++ b/packages/theme/template/Checkbox/Checkbox.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 
 import ToggleIcon from '../ToggleIcon';
 
-import css from './Checkbox.module.less';
+import * as css from './Checkbox.module.less';
 
 /**
  * A checkbox component, ready to use in MyTheme applications.

--- a/packages/theme/template/CheckboxItem/CheckboxItem.js
+++ b/packages/theme/template/CheckboxItem/CheckboxItem.js
@@ -17,7 +17,7 @@ import PropTypes from 'prop-types';
 import Checkbox from '../Checkbox';
 import ToggleItem from '../ToggleItem';
 
-import componentCss from './CheckboxItem.module.less';
+import * as componentCss from './CheckboxItem.module.less';
 
 /**
  * An item with a checkbox component, ready to use in my-theme applications.

--- a/packages/theme/template/Heading/Heading.js
+++ b/packages/theme/template/Heading/Heading.js
@@ -19,7 +19,7 @@ import compose from 'ramda/src/compose';
 
 import Skinnable from '../Skinnable';
 
-import componentCss from './Heading.module.less';
+import * as componentCss from './Heading.module.less';
 
 /**
  * A labeled Heading component.

--- a/packages/theme/template/Icon/Icon.js
+++ b/packages/theme/template/Icon/Icon.js
@@ -18,7 +18,7 @@ import compose from 'ramda/src/compose';
 
 import Skinnable from '../Skinnable';
 
-import componentCss from './Icon.module.less';
+import * as componentCss from './Icon.module.less';
 
 /**
  * Renders a MyTheme-styled icon without any behavior.

--- a/packages/theme/template/Item/Item.js
+++ b/packages/theme/template/Item/Item.js
@@ -15,7 +15,7 @@ import compose from 'ramda/src/compose';
 
 import Skinnable from '../Skinnable';
 
-import componentCss from './Item.module.less';
+import * as componentCss from './Item.module.less';
 
 /**
  * A MyTheme styled item.

--- a/packages/theme/template/Panels/Panel.js
+++ b/packages/theme/template/Panels/Panel.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 import Skinnable from '../Skinnable';
 
-import componentCss from './Panel.module.less';
+import * as componentCss from './Panel.module.less';
 
 /**
  * A Panel is the standard view container used inside a [Panels]{@link my-theme/Panels.Panels} view

--- a/packages/theme/template/Panels/Panels.js
+++ b/packages/theme/template/Panels/Panels.js
@@ -26,7 +26,7 @@ import Skinnable from '../Skinnable';
 
 import Panel from './Panel';
 
-import componentCss from './Panels.module.less';
+import * as componentCss from './Panels.module.less';
 
 /**
  * Basic Panels component using a `SlideLeftArranger` [arranger]{@link ui/ViewManager.Arranger}

--- a/packages/theme/template/RadioItem/RadioItem.js
+++ b/packages/theme/template/RadioItem/RadioItem.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 import ToggleIcon from '../ToggleIcon';
 import ToggleItem from '../ToggleItem';
 
-import componentCss from './RadioItem.module.less';
+import * as componentCss from './RadioItem.module.less';
 
 /**
  * Renders an `Item` with a radio-dot icon.

--- a/packages/theme/template/SlotItem/SlotItem.js
+++ b/packages/theme/template/SlotItem/SlotItem.js
@@ -31,7 +31,7 @@ import compose from 'ramda/src/compose';
 import {ItemBase} from '../Item';
 import Skinnable from '../Skinnable';
 
-import componentCss from './SlotItem.module.less';
+import * as componentCss from './SlotItem.module.less';
 
 /**
  * A MyTheme styled SlotItem without any behavior.

--- a/packages/theme/template/ThemeDecorator/ThemeDecorator.js
+++ b/packages/theme/template/ThemeDecorator/ThemeDecorator.js
@@ -16,7 +16,7 @@ import Skinnable from '../Skinnable';
 
 import screenTypes from './screenTypes.json';
 
-import css from './ThemeDecorator.module.less';
+import * as css from './ThemeDecorator.module.less';
 
 /**
  * Default config for {@link my-theme/ThemeDecorator.ThemeDecorator}.

--- a/packages/theme/template/ToggleItem/ToggleItem.js
+++ b/packages/theme/template/ToggleItem/ToggleItem.js
@@ -29,7 +29,7 @@ import compose from 'ramda/src/compose';
 import Skinnable from '../Skinnable';
 import {SlotItemBase} from '../SlotItem';
 
-import componentCss from './ToggleItem.module.less';
+import * as componentCss from './ToggleItem.module.less';
 
 /**
  * A MyTheme styled toggle [Item]{@link my-theme/Item} without any behavior.

--- a/packages/typescript/template/src/App/App.tsx
+++ b/packages/typescript/template/src/App/App.tsx
@@ -4,7 +4,7 @@ import ThemeDecorator from '@enact/sandstone/ThemeDecorator';
 
 import MainPanel from '../views/MainPanel';
 
-import css from './App.module.less';
+import * as css from './App.module.less';
 
 const App = kind({
 	name: 'App',

--- a/packages/webosauto/template/src/App/App.js
+++ b/packages/webosauto/template/src/App/App.js
@@ -4,7 +4,7 @@ import {Panels} from '@enact/agate/Panels';
 
 import MainPanel from '../views/MainPanel';
 
-import css from './App.module.less';
+import * as css from './App.module.less';
 
 const App = kind({
 	name: 'App',

--- a/packages/webostv/template/src/App/App.js
+++ b/packages/webostv/template/src/App/App.js
@@ -6,7 +6,7 @@ import MainPanel from '../views/MainPanel';
 
 import './attachErrorHandler';
 
-import css from './App.module.less';
+import * as css from './App.module.less';
 
 const App = kind({
 	name: 'App',


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
css-loader v7 migration
https://github.com/webpack-contrib/css-loader/releases/tag/v7.0.0

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Change import style
```
// Before
import style from "./style.css";

//After
import * as style from "./style.css";
```

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Those changes should be descripted on migration guide, if decided to merge.
- Those changes should be synced with tools including css-loader v7(cli, storybook-utils).
- About `Moonstone`: This template decide not to update css-loader.

### Links
[//]: # (Related issues, references)
WRQ-19494

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)